### PR TITLE
chore: update image platform

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -65,7 +65,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
-          platforms: linux/arm64 # for Raspberry Pi
+          platforms: linux/amd64 # for mr4x2 server
           tags: hoangndst/hoangndst-homepage:latest
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/arm64 # for Raspberry Pi
+          platforms: linux/amd64 # for mr4x2 server
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.REGISTRY_PREFIX }}:${{ steps.get_version.outputs.VERSION }}
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max


### PR DESCRIPTION
This pull request updates the target platform in two GitHub Actions workflow files to ensure compatibility with the `mr4x2` server. The changes involve switching from `linux/arm64` (used for Raspberry Pi) to `linux/amd64`.

Platform updates in workflows:

* [`.github/workflows/pull.yaml`](diffhunk://#diff-83e2836715c4dec4422ba842f923c53b0c39481d44f012abd98f1e9f316deecaL68-R68): Changed the `platforms` field from `linux/arm64` to `linux/amd64` for compatibility with the `mr4x2` server.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL76-R76): Updated the `platforms` field from `linux/arm64` to `linux/amd64` to align with the `mr4x2` server requirements during the release process.